### PR TITLE
Created `/posts/${id}` page, with a single post view

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "vite-tsconfig-paths": "^4.2.1"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "graphql-request": "^7.1.2",
     "tailwind-merge": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -798,6 +801,9 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2937,6 +2943,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   clsx@2.1.1: {}
 

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -19,7 +19,7 @@ export const PostCard = component$<PostCardProps>((props) => {
 
   return (
     <div class="rounded-lg border bg-card p-4 transition-shadow hover:shadow-lg">
-      <Link href={`/post/${post.id}`}>
+      <Link href={`/posts/${post.id}`}>
         <h2
           class="mb-2 text-xl font-semibold"
           dangerouslySetInnerHTML={highlightText(post.title)}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import { component$, Slot } from "@builder.io/qwik";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "~/lib/utils";
+
+const buttonVariants = cva(
+  `inline-flex items-center jusitfy-center rounded-md text-sm
+  font-medium transition-colors focus-visible:outline-none focus-visible:ring-2
+  focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50
+  disabled:pointer-events-none ring-offset-background`,
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-red-500 text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "underline-offset-4 hover:underline text-primary",
+      },
+      size: {
+        default: "h-10 py-2 px-4",
+        sm: "h-9 px-3 rounded-md",
+        lg: "h-11 px-8 rounded-md",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps extends VariantProps<typeof buttonVariants> {
+  class?: string;
+}
+
+export const Button = component$<ButtonProps>((props) => {
+  const { variant, size, class: className, ...rest } = props;
+
+  return (
+    <button
+      class={cn(buttonVariants({ variant, size, class: className }))}
+      {...rest}
+    >
+      <Slot />
+    </button>
+  );
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,3 +9,11 @@ export function truncateText(text: string, maxLength: number = 100) {
   if (text.length <= maxLength) return text;
   return text.slice(0, maxLength) + '...'; 
 }
+
+export function formatDate(date: string | Date) {
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+}

--- a/src/routes/posts/[id]/index.tsx
+++ b/src/routes/posts/[id]/index.tsx
@@ -3,3 +3,43 @@ import { routeLoader$ } from "@builder.io/qwik-city";
 import { graphqlClient } from "~/lib/graphql/client";
 import { GET_POST } from "~/lib/graphql/queries";
 import { formatDate } from "~/lib/utils";
+import { Button } from "~/components/ui/button";
+import { Link } from "@builder.io/qwik-city";
+import { PostResponse } from "~/types/post";
+
+export const usePostLoader = routeLoader$(async ({ params }) => {
+  const { post } = await graphqlClient.request<PostResponse>(GET_POST, {
+    id: params.id,
+  });
+
+  return post;
+});
+
+// As the GraphQL API does not return a createdAt field, we gonna create a random date for the post.
+
+const randomDate = () => {
+  const start = new Date(2021, 0, 1);
+  const end = new Date();
+  return new Date(
+    start.getTime() + Math.random() * (end.getTime() - start.getTime()),
+  );
+};
+
+export default component$(() => {
+  const post = usePostLoader();
+
+  return (
+    <section>
+      <div class="mb-6">
+        <Link href="/">
+          <Button variant="outline">← Back to Posts</Button>
+        </Link>
+      </div>
+      <article class="prose prose-lg max-w-none">
+        <h1 class="mb-4 text-4xl font-bold">{post.value.title}</h1>
+        <p class="mb-6 text-muted-foreground">{formatDate(randomDate())}</p>
+        <div class="whitespace-pre-wrap">{post.value.body}</div>
+      </article>
+    </section>
+  );
+});

--- a/src/routes/posts/[id]/index.tsx
+++ b/src/routes/posts/[id]/index.tsx
@@ -1,0 +1,5 @@
+import { component$ } from "@builder.io/qwik";
+import { routeLoader$ } from "@builder.io/qwik-city";
+import { graphqlClient } from "~/lib/graphql/client";
+import { GET_POST } from "~/lib/graphql/queries";
+import { formatDate } from "~/lib/utils";

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -9,6 +9,10 @@ type Meta = {
   totalCount: number;
 };
 
+export interface PostResponse {
+  post: Post;
+}
+
 export interface PostsResponse {
   posts: {
     data: Post[];


### PR DESCRIPTION
In this PR we have done:

- Created a new route `/posts/${id}` that consumes the GraphQL API, returing the post data from the specific ID
- Created a new util function `formatDate`, that handles Dates in the application
- Created a `randomDate` function, since the GraphQL API **does not** return a post timestamp

